### PR TITLE
Fix/import paths

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -43,19 +43,19 @@ except Exception as exc:
     OPTIONAL_IMPORT_ERRORS.append(("speech_recognition", exc))
 
 try:
-    from text_to_speech import TextToSpeech  # type: ignore
+    from .text_to_speech import TextToSpeech  # type: ignore
 except Exception as exc:
     TextToSpeech = None  # type: ignore[assignment]
     OPTIONAL_IMPORT_ERRORS.append(("text_to_speech", exc))
 
 try:
-    from vtuber_model import VtuberModel  # type: ignore
+    from .vtuber_model import VtuberModel  # type: ignore
 except Exception as exc:
     VtuberModel = None  # type: ignore[assignment]
     OPTIONAL_IMPORT_ERRORS.append(("vtuber_model", exc))
 
-from emotion_analyzer import EmotionAnalyzer
-from topic_bandit import TopicBandit
+from .emotion_analyzer import EmotionAnalyzer
+from .topic_bandit import TopicBandit
 
 # VTuberAIのインスタンス
 vtuber = None


### PR DESCRIPTION
OpenAI クライアント生成を必須にせず、キー未設定時は警告を出して None を保持し、フォールバック応答に切り替わるように整備しました (api/main.py:268, api/main.py:520, api/main.py:664).
フォールバック時の会話履歴・表情更新・バンディット履歴を安全に処理するためのヘルパーを追加し、self.model 未初期化時にも落ちないようガードを挿入しました (api/main.py:332, api/main.py:545, api/main.py:686).
感情分析モジュールは OpenAI クライアント初期化に失敗しても起動を阻害せず、デフォルト感情を返す仕組みに変更しました (api/emotion_analyzer.py:10, api/emotion_analyzer.py:51, api/emotion_analyzer.py:74).
トピックバンディットも同様にキー欠如時はランダム選択や固定スコアへフォールバックし、再設定されたクライアントを受け付けるようにしました (api/topic_bandit.py:10, api/topic_bandit.py:49, api/topic_bandit.py:84).